### PR TITLE
Remove redundant use of `Object#to_s`.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
   end
 
   def chatroom_meta_for(chattable)
-    tag :meta, name: 'chatroom-channel', content: "/chat/#{chattable.class.to_s}/#{chattable.id}"
+    tag :meta, name: 'chatroom-channel', content: "/chat/#{chattable.class}/#{chattable.id}"
   end
 
   def user_meta_for(user)


### PR DESCRIPTION
Shouldn't need to use #to_s when `chattable.class` is already being interpolated into the string.
